### PR TITLE
Add platform in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,9 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
+        "platform": {
+            "php": "7.4.0"
+        },
         "sort-packages": true,
         "optimize-autoloader": true,
         "allow-plugins": {


### PR DESCRIPTION
So that "composer install" generate a usable tree on PHP 7.4, 8.0 or 8.1, whatever is used version